### PR TITLE
[feat] 광고 상세 정보 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 
 	// DB 연결용 MySQL 드라이버
@@ -45,10 +46,10 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	// Spring Security
+	//security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	// AWS SDK BOM
+	//S3
 	implementation platform("software.amazon.awssdk:bom:2.25.16")
 
 	// AWS SDK S3 및 인증 모듈
@@ -74,6 +75,10 @@ dependencies {
 	testImplementation 'org.mockito:mockito-core'
 	testImplementation 'org.mockito:mockito-junit-jupiter'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	//Pair 사용
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/oss_project/controller/AdSlotController.java
+++ b/src/main/java/com/example/oss_project/controller/AdSlotController.java
@@ -3,11 +3,11 @@ package com.example.oss_project.controller;
 import com.example.oss_project.core.common.CommonResponseDto;
 import com.example.oss_project.domain.request.adSlot.AdSlotRegisterRequestDto;
 import com.example.oss_project.domain.request.adSlot.AdSlotSearchRequestDto;
-import com.example.oss_project.domain.response.adSlot.AdSlotBidHistoryResponseDto;
-import com.example.oss_project.domain.response.adSlot.AdminAdSlotListResponseDto;
-import com.example.oss_project.domain.response.adSlot.AdminAdSlotResponseDto;
 import com.example.oss_project.domain.response.adSlot.AdSlotResponseDto;
 import com.example.oss_project.service.adSlot.AdSlotService;
+import com.example.oss_project.service.adSlot.InforAdSlotService;
+import com.example.oss_project.domain.response.adSlot.AdSlotBidHistoryResponseDto;
+import com.example.oss_project.domain.response.adSlot.AdminAdSlotListResponseDto;
 import com.example.oss_project.service.adSlot.AdminAdSlotSearchService;
 import com.example.oss_project.service.adSlot.AdSlotBidHistorySearchService;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +27,7 @@ public class AdSlotController {
     private final AdSlotService adSlotService;
     private final AdminAdSlotSearchService adminAdSlotSearchService;
     private final AdSlotBidHistorySearchService adSlotBidHistorySearchService;
+    private final InforAdSlotService inforAdSlotService;
     private final S3Util s3Util;
 
     @PostMapping("/regist")
@@ -58,6 +59,14 @@ public class AdSlotController {
                 request.price()
         );
         return CommonResponseDto.ok(result);
+    }
+
+    @GetMapping("/infor/{adSlotId}")
+    public CommonResponseDto<?> infoAdSlot(
+            @PathVariable Long adSlotId,
+            @RequestParam(defaultValue = "week") String type  // "week" or "month"
+    ){
+        return CommonResponseDto.ok(inforAdSlotService.findBasicInfor(adSlotId,type));
     }
 
     @GetMapping("/admin/{adminId}")

--- a/src/main/java/com/example/oss_project/controller/AuthController.java
+++ b/src/main/java/com/example/oss_project/controller/AuthController.java
@@ -36,6 +36,4 @@ public class AuthController {
     ){
         return CommonResponseDto.ok(signUpService.signUp(signUpRequestDto));
     }
-
-
 }

--- a/src/main/java/com/example/oss_project/core/exception/ErrorCode.java
+++ b/src/main/java/com/example/oss_project/core/exception/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     NOT_FOUND_AD("40402", HttpStatus.NOT_FOUND, "해당 광고가 존재하지 않습니다."),
     NOT_FOUND_ADSLOT("40403", HttpStatus.NOT_FOUND, "해당 광고 자리가 존재하지 않습니다."),
     NOT_FOUND_ADMIN("40404", HttpStatus.NOT_FOUND, "해당 매체사가 존재하지 않습니다."),
+    NOT_FOUND_CVINFO("40405", HttpStatus.NOT_FOUND, "해당 광고 정보가 존재하지 않습니다."),
 
 
     /**

--- a/src/main/java/com/example/oss_project/core/security/SecurityConfig.java
+++ b/src/main/java/com/example/oss_project/core/security/SecurityConfig.java
@@ -25,8 +25,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/ads/my").hasRole("ROLE_USER")
-                        .requestMatchers("/ads/adslot/regist").hasRole("ROLE_ADMIN")
+                        .requestMatchers("/ads/my").hasRole("USER")
+                        .requestMatchers("/ads/adslot/regist").hasRole("ADMIN")
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/example/oss_project/domain/entity/AdSlot.java
+++ b/src/main/java/com/example/oss_project/domain/entity/AdSlot.java
@@ -1,5 +1,6 @@
 package com.example.oss_project.domain.entity;
 
+import com.example.oss_project.domain.type.AdSlotStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -24,6 +25,9 @@ public class AdSlot {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "admin_id")
     private Admin admin;
+
+    @Column(name = "ad_slot_status")
+    private AdSlotStatus adSlotStatus;
 
     @Column(name = "ad_slot_name")
     private String adSlotName;

--- a/src/main/java/com/example/oss_project/domain/entity/AdSlot.java
+++ b/src/main/java/com/example/oss_project/domain/entity/AdSlot.java
@@ -6,13 +6,15 @@ import lombok.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "adSlot")
+@Table(name = "ad_slot")
 public class AdSlot {
     @Id
     @Column(name = "ad_slot_id")
@@ -23,14 +25,17 @@ public class AdSlot {
     @JoinColumn(name = "admin_id")
     private Admin admin;
 
+    @Column(name = "ad_slot_name")
+    private String adSlotName;
+
+    @Column(name = "ad_start_date")
+    private LocalDateTime startDate;
+
     @OneToMany(mappedBy = "adSlot", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<CvInfo> cvInfos;
 
     @OneToMany(mappedBy = "adSlot", cascade = CascadeType.ALL)
     private List<MinPrice> minPrices = new ArrayList<>();
-
-    @Column(name = "ad_slot_name")
-    private String slotName;
 
     @Column(name = "ad_slot_description")
     private String description;
@@ -46,9 +51,6 @@ public class AdSlot {
 
     @Column(name = "size")
     private String size;
-
-    @Column(name = "min_price")
-    private Long minPrice;
 
     @Column(name = "ad_loc_x")
     private Double locX;

--- a/src/main/java/com/example/oss_project/domain/entity/BidHistory.java
+++ b/src/main/java/com/example/oss_project/domain/entity/BidHistory.java
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "bidHistory")
+@Table(name = "bid_history")
 public class BidHistory extends BaseEntity {
     @Id
     @Column(name = "bid_id")

--- a/src/main/java/com/example/oss_project/domain/entity/CvInfo.java
+++ b/src/main/java/com/example/oss_project/domain/entity/CvInfo.java
@@ -26,6 +26,14 @@ public class CvInfo {
 
     @Column(name = "cv_info_mid_time",nullable = false)
     private Double midTime;
+    @Column(name = "cv_info_min_time",nullable = false)
+    private Double minTime;
+    @Column(name = "cv_info_q1_time",nullable = false)
+    private Double q1Time;
+    @Column(name = "cv_info_q3_time",nullable = false)
+    private Double q3Time;
+    @Column(name = "cv_info_max_time",nullable = false)
+    private Double maxTime;
 
     @Column(name = "cv_info_exposure_score",nullable = false)
     private Double exposureScore;

--- a/src/main/java/com/example/oss_project/domain/response/adSlot/AdslotInforAdResponseDto.java
+++ b/src/main/java/com/example/oss_project/domain/response/adSlot/AdslotInforAdResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.oss_project.domain.response.adSlot;
+
+import com.example.oss_project.domain.response.cvInfo.AttentionRateResponseDto;
+import com.example.oss_project.domain.response.cvInfo.ExposureScoreResponseDto;
+import com.example.oss_project.domain.response.cvInfo.NavigateResponseDto;
+import com.example.oss_project.domain.response.cvInfo.StayTimeResponseDto;
+import com.example.oss_project.domain.response.cvInfo.ViewCountResponseDto;
+
+public record AdslotInforAdResponseDto(
+        NavigateResponseDto navigateResponseDto,
+        ExposureScoreResponseDto exposureScoreResponseDto,
+        AttentionRateResponseDto attentionRateResponseDto,
+        ViewCountResponseDto viewCountResponseDto,
+        StayTimeResponseDto stayTimeResponseDto
+) {
+}

--- a/src/main/java/com/example/oss_project/domain/response/adSlot/ViewCountResponseDto.java
+++ b/src/main/java/com/example/oss_project/domain/response/adSlot/ViewCountResponseDto.java
@@ -1,0 +1,9 @@
+package com.example.oss_project.domain.response.adSlot;
+
+import java.util.List;
+
+public record ViewCountResponseDto(
+        List<Long> viewCounts, // 시간대별 통행량
+        Long total             // 총 통행량
+) {
+}

--- a/src/main/java/com/example/oss_project/domain/response/cvInfo/AttentionRateResponseDto.java
+++ b/src/main/java/com/example/oss_project/domain/response/cvInfo/AttentionRateResponseDto.java
@@ -1,0 +1,9 @@
+package com.example.oss_project.domain.response.cvInfo;
+
+import java.util.List;
+
+public record AttentionRateResponseDto(
+        Double avgAttentionRate, // 평균 응시율
+        List<Double> attentionRations //시간대별 응시율
+) {
+}

--- a/src/main/java/com/example/oss_project/domain/response/cvInfo/CvInfoStayTimeDto.java
+++ b/src/main/java/com/example/oss_project/domain/response/cvInfo/CvInfoStayTimeDto.java
@@ -1,0 +1,11 @@
+package com.example.oss_project.domain.response.cvInfo;
+
+public record CvInfoStayTimeDto(
+        String time,
+        Double midTime,
+        Double minTime,
+        Double q1Time,
+        Double q3Time,
+        Double maxTime
+) {
+}

--- a/src/main/java/com/example/oss_project/domain/response/cvInfo/ExposureScoreResponseDto.java
+++ b/src/main/java/com/example/oss_project/domain/response/cvInfo/ExposureScoreResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.oss_project.domain.response.cvInfo;
+
+import java.util.List;
+
+public record ExposureScoreResponseDto(
+        List<List<Double>> exposureScores, // 노출 점수 표
+        Double avgExposureScore
+
+) {
+}

--- a/src/main/java/com/example/oss_project/domain/response/cvInfo/NavigateResponseDto.java
+++ b/src/main/java/com/example/oss_project/domain/response/cvInfo/NavigateResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.oss_project.domain.response.cvInfo;
+
+import java.time.LocalDateTime;
+
+public record NavigateResponseDto(
+        String adName,
+        Long avgBidMoney,
+        LocalDateTime startAdTime,
+        LocalDateTime endAdTime
+) {
+}

--- a/src/main/java/com/example/oss_project/domain/response/cvInfo/NavigateResponseDto.java
+++ b/src/main/java/com/example/oss_project/domain/response/cvInfo/NavigateResponseDto.java
@@ -1,11 +1,15 @@
 package com.example.oss_project.domain.response.cvInfo;
 
+import com.example.oss_project.domain.type.AdSlotStatus;
+import com.example.oss_project.domain.type.BidStatus;
+
 import java.time.LocalDateTime;
 
 public record NavigateResponseDto(
         String adName,
         Long avgBidMoney,
         LocalDateTime startAdTime,
-        LocalDateTime endAdTime
+        LocalDateTime endAdTime,
+        AdSlotStatus bidStatus
 ) {
 }

--- a/src/main/java/com/example/oss_project/domain/response/cvInfo/StayTimeResponseDto.java
+++ b/src/main/java/com/example/oss_project/domain/response/cvInfo/StayTimeResponseDto.java
@@ -1,0 +1,9 @@
+package com.example.oss_project.domain.response.cvInfo;
+
+import java.util.List;
+
+public record StayTimeResponseDto(
+        Double avgStaytime,
+        List<CvInfoStayTimeDto> stayTimes
+) {
+}

--- a/src/main/java/com/example/oss_project/domain/response/cvInfo/ViewCountResponseDto.java
+++ b/src/main/java/com/example/oss_project/domain/response/cvInfo/ViewCountResponseDto.java
@@ -1,0 +1,9 @@
+package com.example.oss_project.domain.response.cvInfo;
+
+import java.util.List;
+
+public record ViewCountResponseDto(
+        List<Long> timeViewCount, // 시간대별 통행량
+        Long avgViewCount
+) {
+}

--- a/src/main/java/com/example/oss_project/domain/type/AdSlotStatus.java
+++ b/src/main/java/com/example/oss_project/domain/type/AdSlotStatus.java
@@ -1,0 +1,11 @@
+package com.example.oss_project.domain.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AdSlotStatus {
+    CONTINUE("진행중"),
+    FINISH("입찰 완료");
+
+    private final String adSlotStatus;
+}

--- a/src/main/java/com/example/oss_project/repository/adSlot/AdSlotRepository.java
+++ b/src/main/java/com/example/oss_project/repository/adSlot/AdSlotRepository.java
@@ -3,9 +3,11 @@ package com.example.oss_project.repository.adSlot;
 import com.example.oss_project.core.exception.CustomException;
 import com.example.oss_project.core.exception.ErrorCode;
 import com.example.oss_project.domain.entity.AdSlot;
+import com.example.oss_project.domain.entity.CvInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -26,4 +28,6 @@ public class AdSlotRepository {
     public AdSlot save(AdSlot adSlot){
         return adslotJpaRepository.save(adSlot);
     }
+
+
 }

--- a/src/main/java/com/example/oss_project/repository/adSlot/AdslotJpaRepository.java
+++ b/src/main/java/com/example/oss_project/repository/adSlot/AdslotJpaRepository.java
@@ -1,10 +1,12 @@
 package com.example.oss_project.repository.adSlot;
 
 import com.example.oss_project.domain.entity.AdSlot;
+import com.example.oss_project.domain.entity.CvInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +17,6 @@ public interface AdslotJpaRepository extends JpaRepository<AdSlot,Long> {
 
     @Query("SELECT a FROM AdSlot a LEFT JOIN FETCH a.cvInfos WHERE a.admin.adminId = :adminId")
     List<AdSlot> findByAdmin_AdminIdWithCvInfos(@Param("adminId") Long adminId);
+
+
 }

--- a/src/main/java/com/example/oss_project/repository/auth/AuthAdminJpaRepository.java
+++ b/src/main/java/com/example/oss_project/repository/auth/AuthAdminJpaRepository.java
@@ -3,5 +3,8 @@ package com.example.oss_project.repository.auth;
 import com.example.oss_project.domain.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AuthAdminJpaRepository extends JpaRepository<Admin, Long> {
+    public Optional<Admin> findByAdminLoginId(String loginId);
 }

--- a/src/main/java/com/example/oss_project/repository/auth/AuthRepository.java
+++ b/src/main/java/com/example/oss_project/repository/auth/AuthRepository.java
@@ -14,11 +14,11 @@ public class AuthRepository {
     private final AuthAdminJpaRepository authAdminJpaRepository;
 
     public User findByUserLoginId(String userLoginId){
-        return authUserJpaRepository.findByLoginId(userLoginId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+        return authUserJpaRepository.findByUserLoginId(userLoginId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
     }
 
     public Admin findByAdminLoginId(String loginId){
-        return authAdminJpaRepository.findByLoginId(loginId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ADMIN));
+        return authAdminJpaRepository.findByAdminLoginId(loginId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ADMIN));
     }
 
     public User save(User user){ return authUserJpaRepository.save(user); }

--- a/src/main/java/com/example/oss_project/repository/auth/AuthUserJpaRepository.java
+++ b/src/main/java/com/example/oss_project/repository/auth/AuthUserJpaRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AuthUserJpaRepository extends JpaRepository<User, Long> {
-    Optional<User> findByLoginId(String loginId);
+    Optional<User> findByUserLoginId(String loginId);
 }

--- a/src/main/java/com/example/oss_project/repository/bidHistory/BidHistoryJpaRepository.java
+++ b/src/main/java/com/example/oss_project/repository/bidHistory/BidHistoryJpaRepository.java
@@ -3,6 +3,7 @@ package com.example.oss_project.repository.bidHistory;
 import com.example.oss_project.domain.entity.Ad;
 import com.example.oss_project.domain.entity.BidHistory;
 import com.example.oss_project.domain.entity.AdSlot;
+import com.example.oss_project.domain.entity.BidHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/example/oss_project/repository/bidHistory/BidHistoryRepository.java
+++ b/src/main/java/com/example/oss_project/repository/bidHistory/BidHistoryRepository.java
@@ -1,0 +1,28 @@
+package com.example.oss_project.repository.bidHistory;
+
+import com.example.oss_project.domain.entity.Ad;
+import com.example.oss_project.domain.entity.AdSlot;
+import com.example.oss_project.domain.entity.BidHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BidHistoryRepository {
+
+    private final BidHistoryJpaRepository bidHistoryJpaRepository;
+
+    public List<BidHistory> findByAdSlot(AdSlot adSlot){
+        return bidHistoryJpaRepository.findByAdSlot(adSlot);
+    }
+
+    public List<BidHistory> findByAd_AdId(Long adId){
+        return bidHistoryJpaRepository.findByAd_AdId(adId);
+    }
+    public BidHistory findTopByAdOrderByBidIdDesc(Ad ad){
+        return bidHistoryJpaRepository.findTopByAdOrderByBidIdDesc(ad);
+    }
+
+}

--- a/src/main/java/com/example/oss_project/repository/cvInfo/CvInfoJpaRepository.java
+++ b/src/main/java/com/example/oss_project/repository/cvInfo/CvInfoJpaRepository.java
@@ -4,11 +4,17 @@ import com.example.oss_project.domain.entity.AdSlot;
 import com.example.oss_project.domain.entity.CvInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.swing.text.html.Option;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface CvInfoJpaRepository extends JpaRepository<CvInfo,Long> {
+    public List<CvInfo> findByAdSlotOrderByTimeStampDesc(AdSlot adSlot);
     List<CvInfo> findByAdSlot(AdSlot adSlot);
     Optional<CvInfo> findByAdSlotAndTimeStamp(AdSlot adSlot, LocalDateTime timeStamp);
+    public List<CvInfo> findByAdSlotAndTimeStampBetweenOrderByTimeStampDesc(
+            AdSlot adSlot, LocalDateTime start, LocalDateTime end
+    );
+    public Optional<CvInfo> findFirstByAdSlotOrderByTimeStampDesc(AdSlot adSlot);
 }

--- a/src/main/java/com/example/oss_project/repository/cvInfo/CvInfoRepository.java
+++ b/src/main/java/com/example/oss_project/repository/cvInfo/CvInfoRepository.java
@@ -1,0 +1,23 @@
+package com.example.oss_project.repository.cvInfo;
+
+import com.example.oss_project.domain.entity.AdSlot;
+import com.example.oss_project.domain.entity.CvInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CvInfoRepository {
+
+    private final CvInfoJpaRepository cvInfoJpaRepository;
+
+    public List<CvInfo> findByAdSlotOrderByTimeStampDesc(AdSlot adSlot){
+        return cvInfoJpaRepository.findByAdSlotOrderByTimeStampDesc(adSlot);
+    }
+
+    public List<CvInfo> findByAdSlot(AdSlot adSlot){
+        return cvInfoJpaRepository.findByAdSlot(adSlot);
+    }
+}

--- a/src/main/java/com/example/oss_project/repository/cvInfo/CvInfoRepository.java
+++ b/src/main/java/com/example/oss_project/repository/cvInfo/CvInfoRepository.java
@@ -5,6 +5,7 @@ import com.example.oss_project.domain.entity.CvInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -20,4 +21,12 @@ public class CvInfoRepository {
     public List<CvInfo> findByAdSlot(AdSlot adSlot){
         return cvInfoJpaRepository.findByAdSlot(adSlot);
     }
+
+    public List<CvInfo> findByAdSlotAndTimeStampBetweenOrderByTimeStampDesc(
+            AdSlot adSlot, LocalDateTime start, LocalDateTime end
+    ){
+        return cvInfoJpaRepository.findByAdSlotAndTimeStampBetweenOrderByTimeStampDesc(adSlot,start,end);
+    }
+
+
 }

--- a/src/main/java/com/example/oss_project/service/ad/AdService.java
+++ b/src/main/java/com/example/oss_project/service/ad/AdService.java
@@ -11,6 +11,10 @@ import com.example.oss_project.repository.adSlot.AdSlotRepository;
 import com.example.oss_project.repository.bidHistory.BidHistoryJpaRepository;
 import com.example.oss_project.repository.cvInfo.CvInfoJpaRepository;
 import com.example.oss_project.repository.user.UserRepository;
+import com.example.oss_project.repository.adSlot.AdSlotRepository;
+import com.example.oss_project.repository.bidHistory.BidHistoryRepository;
+import com.example.oss_project.repository.cvInfo.CvInfoRepository;
+import com.example.oss_project.repository.user.UserJpaRepository;
 import com.example.oss_project.domain.request.ad.AdRegisterRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -136,7 +140,6 @@ public class AdService {
                         cvInfoDtos = List.of();
                     }
 
-                    // (아래는 기존 코드 그대로)
                     return new AdSlotSummaryResponseDto(
                             adSlot != null ? adSlot.getLocalName() : null,
                             bidHistory.getBidMoney(),

--- a/src/main/java/com/example/oss_project/service/adSlot/AdSlotService.java
+++ b/src/main/java/com/example/oss_project/service/adSlot/AdSlotService.java
@@ -2,10 +2,10 @@ package com.example.oss_project.service.adSlot;
 
 import com.example.oss_project.core.kakao.KakaoApiUtil;
 import com.example.oss_project.domain.entity.BidHistory;
-import com.example.oss_project.domain.entity.MinPrice;
-import com.example.oss_project.domain.request.adSlot.AdSlotRegisterRequestDto;
 import com.example.oss_project.domain.entity.AdSlot;
 import com.example.oss_project.domain.entity.Admin;
+import com.example.oss_project.domain.entity.MinPrice;
+import com.example.oss_project.domain.request.adSlot.AdSlotRegisterRequestDto;
 import com.example.oss_project.domain.request.minPrice.MinPriceRegisterRequestDto;
 import com.example.oss_project.domain.response.adSlot.AdSlotResponseDto;
 import com.example.oss_project.domain.type.BidStatus;
@@ -109,7 +109,7 @@ public class AdSlotService {
                 if (price == null || maxBidHistory.getBidMoney() <= price) {
                     result.add(new AdSlotResponseDto(
                             adSlot.getAdSlotId(),
-                            adSlot.getSlotName(),
+                            adSlot.getAdSlotName(),
                             adSlot.getAddress(),
                             maxBidHistory.getBidMoney(),
                             maxBidHistory.getBidStatus() != null ? maxBidHistory.getBidStatus().ordinal() : null

--- a/src/main/java/com/example/oss_project/service/adSlot/DateRangeUtil.java
+++ b/src/main/java/com/example/oss_project/service/adSlot/DateRangeUtil.java
@@ -1,0 +1,45 @@
+package com.example.oss_project.service.adSlot;
+
+
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class DateRangeUtil {
+    public static Pair<LocalDateTime, LocalDateTime> getRangeByType(String type, LocalDateTime latestTime) {
+        if (latestTime == null) {
+            throw new IllegalArgumentException("latestTime은 null일 수 없습니다.");
+        }
+
+        LocalDate latestDate = latestTime.toLocalDate();
+        LocalDateTime start;
+        LocalDateTime end;
+
+        switch (type) {
+            case "day":
+                // 하루 전 날짜의 00:00 ~ 23:59
+                LocalDate oneDayBefore = latestDate.minusDays(1);
+                start = oneDayBefore.atStartOfDay(); // 00:00
+                end = oneDayBefore.atTime(23, 59, 59); // 23:59:59
+                break;
+
+            case "week":
+                start = latestDate.minusDays(6).atStartOfDay(); // 7일 전
+                end = latestDate.atTime(23, 59, 59);
+                break;
+
+            case "month":
+                start = latestDate.minusDays(29).atStartOfDay(); // 30일 전
+                end = latestDate.atTime(23, 59, 59);
+                break;
+
+            default:
+                throw new IllegalArgumentException("잘못된 type: " + type);
+        }
+
+        return Pair.of(start, end);
+    }
+}
+

--- a/src/main/java/com/example/oss_project/service/adSlot/InforAdSlotService.java
+++ b/src/main/java/com/example/oss_project/service/adSlot/InforAdSlotService.java
@@ -83,7 +83,8 @@ public class InforAdSlotService {
                 adSlot.getAdSlotName(),
                 makeAvgBidMoney(bidHistories),
                 adSlot.getStartDate(),
-                adSlot.getStartDate().plusDays(1)
+                adSlot.getStartDate().plusDays(1),
+                adSlot.getAdSlotStatus()
         );
 
         AttentionRateResponseDto attentionRateResponseDto = new AttentionRateResponseDto(

--- a/src/main/java/com/example/oss_project/service/adSlot/InforAdSlotService.java
+++ b/src/main/java/com/example/oss_project/service/adSlot/InforAdSlotService.java
@@ -1,0 +1,279 @@
+package com.example.oss_project.service.adSlot;
+
+import com.example.oss_project.domain.entity.AdSlot;
+import com.example.oss_project.domain.entity.BidHistory;
+import com.example.oss_project.domain.entity.CvInfo;
+import com.example.oss_project.domain.response.adSlot.AdslotInforAdResponseDto;
+import com.example.oss_project.domain.response.cvInfo.AttentionRateResponseDto;
+
+import com.example.oss_project.domain.response.cvInfo.CvInfoStayTimeDto;
+import com.example.oss_project.domain.response.cvInfo.ExposureScoreResponseDto;
+import com.example.oss_project.domain.response.cvInfo.NavigateResponseDto;
+import com.example.oss_project.domain.response.cvInfo.StayTimeResponseDto;
+import com.example.oss_project.domain.response.cvInfo.ViewCountResponseDto;
+import com.example.oss_project.repository.adSlot.AdSlotRepository;
+import com.example.oss_project.repository.bidHistory.BidHistoryRepository;
+import com.example.oss_project.repository.cvInfo.CvInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class InforAdSlotService {
+    private final AdSlotRepository adSlotRepository;
+    private final CvInfoRepository cvInfoRepository;
+    private final BidHistoryRepository bidHistoryRepository;
+
+    // 광고 자리 상세 정보 페이지 첫 화면
+    public AdslotInforAdResponseDto findBasicInfor(Long adSlotId,String type) {
+        AdSlot adSlot = adSlotRepository.findByAdSlotId(adSlotId);
+        List<BidHistory> bidHistories = bidHistoryRepository.findByAdSlot(adSlot);
+        List<CvInfo> cvInfos = cvInfoRepository.findByAdSlotOrderByTimeStampDesc(adSlot);
+        Pair<List<Long>, Long> viewCountResult=null;
+
+        if (cvInfos.isEmpty()) {
+            throw new IllegalArgumentException("광고 정보가 담기지 않았습니다.");
+        }
+
+        CvInfo latest = cvInfos.get(0);
+
+        // 공통: 최근 7일 범위
+        Pair<LocalDateTime, LocalDateTime> weekRange = DateRangeUtil.getRangeByType("week", latest.getTimeStamp());
+        // 통행량
+        List<CvInfo> viewInfos = cvInfoRepository.findByAdSlotAndTimeStampBetweenOrderByTimeStampDesc(
+                adSlot, weekRange.getLeft(), weekRange.getRight());
+        if (type.equals("week")) {
+            viewCountResult = makeTimeViewCountWithTotal(viewInfos,
+                    weekRange.getLeft().toLocalDate(), weekRange.getRight().toLocalDate());
+        }
+        // 노출 점수
+        Pair<List<List<Double>>, Double> exposureResult = makeExposureScoresWithAverage(
+                viewInfos, weekRange.getLeft().toLocalDate(), weekRange.getRight().toLocalDate());
+
+        // 공통 : 최근 30일 범위
+        Pair<LocalDateTime, LocalDateTime> monthRange = DateRangeUtil.getRangeByType("month", latest.getTimeStamp());
+        List<CvInfo> monthInfos = cvInfoRepository.findByAdSlotAndTimeStampBetweenOrderByTimeStampDesc(
+                adSlot, monthRange.getLeft(), monthRange.getRight());
+        if (type.equals("month")){
+           viewCountResult = makeWeeklyGroupedViewCount(monthInfos,
+                    monthRange.getLeft().toLocalDate(),monthRange.getRight().toLocalDate());
+        }
+
+        // 응시율 (최근 하루)
+        Pair<LocalDateTime, LocalDateTime> dayRange = DateRangeUtil.getRangeByType("day", latest.getTimeStamp());
+        List<CvInfo> dayInfos = cvInfoRepository.findByAdSlotAndTimeStampBetweenOrderByTimeStampDesc(
+                adSlot, dayRange.getLeft(), dayRange.getRight());
+        Pair<List<Double>, Double> attentionResult = makeTimeAttentionRatioWithAverage(dayInfos, dayRange.getLeft().toLocalDate());
+        Pair<List<CvInfoStayTimeDto>,Double> stayTimeDtos = makeTimeStayWithAverage(dayInfos, dayRange.getLeft().toLocalDate());
+
+
+
+        NavigateResponseDto navigateResponseDto = new NavigateResponseDto(
+                adSlot.getAdSlotName(),
+                makeAvgBidMoney(bidHistories),
+                adSlot.getStartDate(),
+                adSlot.getStartDate().plusDays(1)
+        );
+
+        AttentionRateResponseDto attentionRateResponseDto = new AttentionRateResponseDto(
+                attentionResult.getRight(),
+                attentionResult.getLeft()
+        );
+
+        ExposureScoreResponseDto exposureScoreResponseDto = new ExposureScoreResponseDto(
+                exposureResult.getLeft(),
+                exposureResult.getRight()
+        );
+
+        ViewCountResponseDto viewCountResponseDto = new ViewCountResponseDto(
+                viewCountResult.getLeft(),
+                viewCountResult.getRight()
+        );
+        StayTimeResponseDto stayTimeResponseDto = new StayTimeResponseDto(
+                stayTimeDtos.getRight(),
+                stayTimeDtos.getLeft()
+        );
+
+        return new AdslotInforAdResponseDto(
+                navigateResponseDto,
+                exposureScoreResponseDto,
+                attentionRateResponseDto,
+                viewCountResponseDto,
+                stayTimeResponseDto
+        );
+    }
+
+    private Pair<List<CvInfoStayTimeDto>, Double> makeTimeStayWithAverage(
+            List<CvInfo> attentionInfos, LocalDate startDate) {
+
+        List<CvInfoStayTimeDto> dtoList = new ArrayList<>();
+        double totalMidTime = 0.0;
+
+        for (CvInfo info : attentionInfos) {
+            dtoList.add(new CvInfoStayTimeDto(
+                    info.getTimeStamp().toLocalTime().toString(),
+                    info.getMidTime(),
+                    info.getMinTime(),
+                    info.getQ1Time(),
+                    info.getQ3Time(),
+                    info.getMaxTime()
+            ));
+            totalMidTime += info.getMidTime();
+        }
+
+        return Pair.of(dtoList,totalMidTime);
+    }
+
+    private Pair<List<Long>, Long> makeWeeklyGroupedViewCount(
+            List<CvInfo> cvInfos,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        // 4주치 그룹
+        Long[] weeklyCounts = new Long[4];
+        Arrays.fill(weeklyCounts, 0L);
+
+        long total = 0L;
+
+        for (CvInfo cv : cvInfos) {
+            LocalDate date = cv.getTimeStamp().toLocalDate();
+            if (date.isBefore(startDate) || date.isAfter(endDate)) continue;
+
+            int dayIndex = (int) ChronoUnit.DAYS.between(startDate, date);
+            int weekIndex = dayIndex / 7;
+
+            if (weekIndex < 4) {
+                weeklyCounts[weekIndex] += cv.getViewCount();
+                total += cv.getViewCount();
+            }
+        }
+
+        return Pair.of(Arrays.asList(weeklyCounts), total);
+    }
+
+    private Pair<List<Long>, Long> makeTimeViewCountWithTotal(
+            List<CvInfo> cvInfos,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        int days = (int) ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        Long[] arr = new Long[days];
+        Arrays.fill(arr, 0L);
+        long total = 0L;
+
+        for (CvInfo cv : cvInfos) {
+            LocalDate cvDate = cv.getTimeStamp().toLocalDate();
+            if (cvDate.isBefore(startDate) || cvDate.isAfter(endDate)) continue;
+
+            int index = (int) ChronoUnit.DAYS.between(startDate, cvDate);
+            arr[index] += cv.getViewCount();
+            total += cv.getViewCount();
+        }
+
+        return Pair.of(Arrays.asList(arr), total);
+    }
+
+    private Pair<List<Double>, Double> makeTimeAttentionRatioWithAverage(List<CvInfo> cvInfos, LocalDate targetDate) {
+        Double[] time = new Double[12];
+        Arrays.fill(time, 0.0);
+        boolean[] filled = new boolean[12];
+        double total = 0.0;
+        int count = 0;
+
+        for (CvInfo cv : cvInfos) {
+            LocalDateTime ts = cv.getTimeStamp();
+            if (!ts.toLocalDate().equals(targetDate)) continue;
+
+            int hour = ts.getHour();
+            int index = (hour == 0) ? 11 : (hour / 2) - 1;
+            if (index < 0 || index > 11) continue;
+
+            time[index] = cv.getAttentionRatio();
+            filled[index] = true;
+            total += cv.getAttentionRatio();
+            count++;
+        }
+
+        List<Double> result = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            result.add(filled[i] ? time[i] : 0.0);
+        }
+
+        double avg = count == 0 ? 0.0 : Math.round((total / count) * 10.0) / 10.0;
+        return Pair.of(result, avg);
+    }
+
+    private Pair<List<List<Double>>, Double> makeExposureScoresWithAverage(List<CvInfo> cvInfos, LocalDate startDate, LocalDate endDate) {
+        double[][] scoreMatrix = new double[7][12];
+        boolean[][] filled = new boolean[7][12];
+        double totalScore = 0.0;
+        int count = 0;
+
+        for (CvInfo cv : cvInfos) {
+            LocalDateTime ts = cv.getTimeStamp();
+            LocalDate date = ts.toLocalDate();
+            if (date.isBefore(startDate) || date.isAfter(endDate)) continue;
+
+            int hour = ts.getHour();
+            int timeSlot = (hour == 0) ? 11 : (hour / 2) - 1;
+            if (timeSlot < 0 || timeSlot > 11) continue;
+
+            int dayIndex = (int) ChronoUnit.DAYS.between(startDate, date);
+            if (dayIndex < 0 || dayIndex >= 7) continue;
+
+            scoreMatrix[dayIndex][timeSlot] = cv.getExposureScore();
+            filled[dayIndex][timeSlot] = true;
+            totalScore += cv.getExposureScore();
+            count++;
+        }
+
+        List<List<Double>> result = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            List<Double> row = new ArrayList<>();
+            for (int j = 0; j < 12; j++) {
+                row.add(filled[i][j] ? scoreMatrix[i][j] : 0.0);
+            }
+            result.add(row);
+        }
+
+        double avg = count == 0 ? 0.0 : Math.round((totalScore / count) * 10.0) / 10.0;
+        return Pair.of(result, avg);
+    }
+
+    private Long makeAvgBidMoney(List<BidHistory> bidHistories) {
+        return Math.round(bidHistories.stream()
+                .mapToLong(BidHistory::getBidMoney)
+                .average()
+                .orElse(0.0)
+        );
+    }
+
+    public Double makeAvgAttentionRatio(List<CvInfo> cvInfos) {
+        return Math.round(cvInfos.stream()
+                .mapToDouble(CvInfo::getAttentionRatio)
+                .average()
+                .orElse(0.0) * 10
+        ) / 10.0;
+    }
+
+    public Double makeAvgExposureScore(List<CvInfo> cvInfos) {
+        return Math.round(
+                cvInfos.stream()
+                        .mapToDouble(CvInfo::getExposureScore)
+                        .average()
+                        .orElse(0.0) * 10
+        ) / 10.0;
+    }
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈

#10 

## 📝작업 내용

- 네비게이션 바 데이터 (광고 이름, 광고 전체 낙찰 평균 가격, 광고 노출기간 ,  입찰 상)
- 통행량 평균 및 시간별 데이터(type을 통한 분기 (week, month)) 
- 시간대별 노출 점수 평균 및 일주일 2시간단위 12개 데이터
- 응시율 평균 및 시간별 데이터
- 체류시간 평균 및 상자그림데이터(min , q1 , mid , q3 , max)
